### PR TITLE
View와 ViewModel 연결하는 방식 변경 및 관련된 에러해결

### DIFF
--- a/batteryQI_plus/App.xaml
+++ b/batteryQI_plus/App.xaml
@@ -3,9 +3,12 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:fa="http://schemas.awesome.incremented/wpf/xaml/fontawesome.sharp"
              xmlns:local="clr-namespace:batteryQI"
+             xmlns:locator="clr-namespace:batteryQI.ViewModels"
              >
 
     <Application.Resources>
+        <locator:ViewModelLocator x:Key="Locator" />
+        
         <Style x:Key="menuButton" TargetType="Button">
             <Setter Property="Background" Value="Transparent"/>
             <Setter Property="Foreground" Value="#ffffff"/>

--- a/batteryQI_plus/App.xaml.cs
+++ b/batteryQI_plus/App.xaml.cs
@@ -23,6 +23,15 @@ namespace batteryQI
             var loginWindow = new LoginWindow();
             loginWindow.Show();
         }
+
+        protected override void OnExit(ExitEventArgs e)
+        {
+            // ViewModelLocator의 Cleanup 호출
+            var locator = (batteryQI.ViewModels.ViewModelLocator)Resources["Locator"];
+            locator.Cleanup();
+
+            base.OnExit(e);
+        }
     }
 
 }

--- a/batteryQI_plus/Models/Battery.cs
+++ b/batteryQI_plus/Models/Battery.cs
@@ -16,7 +16,7 @@ using System.IO;
 
 namespace batteryQI.Models
 {
-    internal class Battery : ObservableObject
+    public class Battery : ObservableObject
     {
         // 배터리 가용 변수 선언(변동사항 있음. Id나 date 데이터 등은 DB에 기입할 때 필요하지만 관리자가 건들이는 부분은 없음
         private string _usage = ""; // 사용처, 직접 기입

--- a/batteryQI_plus/Models/DBlink.cs
+++ b/batteryQI_plus/Models/DBlink.cs
@@ -155,12 +155,15 @@ namespace batteryQI.Models
             }
             catch (Exception ex)
             {
-                MessageBox.Show($"데이터베이스 접속 오류 \r\n 에러메시지: {ex.Message}", 
+                if (connection == null)
+                    MessageBox.Show($"데이터베이스 접속 오류 \r\n 에러메시지: {ex.Message} 연결 안됨 에러위치: {ex.StackTrace}", 
+                                "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                else
+                    MessageBox.Show($"데이터베이스 접속 오류 \r\n 에러메시지: {ex.Message}",
                                 "Error", MessageBoxButton.OK, MessageBoxImage.Error);
             }
             return resultList;
         }
-
         
 
         // DB select count(*) action

--- a/batteryQI_plus/Models/DBlink.cs
+++ b/batteryQI_plus/Models/DBlink.cs
@@ -31,7 +31,7 @@ namespace batteryQI.Models
         }
     }
 
-    public class DBlink : ObservableObject
+    public class DBlink : ObservableObject, IDisposable
     {
         private string _server = ""; // _server : ip 주소
         private string _port = ""; // _port : 포트번호
@@ -236,9 +236,15 @@ namespace batteryQI.Models
             return result;
         }
 
-        public void Disconnect()
+        // 연결 해제 및 리소스 정리
+        public void Dispose() 
         {
-            connection.Close(); // 연결 해제
+            if (connection != null && connection.State == System.Data.ConnectionState.Open)
+            {
+                connection.Close(); // 연결 해제
+                connection.Dispose();
+                connection = null;
+            }
         }
     }
 }

--- a/batteryQI_plus/Models/Manager.cs
+++ b/batteryQI_plus/Models/Manager.cs
@@ -10,7 +10,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 namespace batteryQI.Models
 {
     // 싱글톤 패턴
-    internal class Manager : ObservableObject
+    public class Manager : ObservableObject
     {
         private int _managerNum;
         private string _managerID; // 담당자 아이디

--- a/batteryQI_plus/ViewModels/Bases/ViewModelBases.cs
+++ b/batteryQI_plus/ViewModels/Bases/ViewModelBases.cs
@@ -9,17 +9,28 @@ using CommunityToolkit.Mvvm.Input;
 using batteryQI.Models;
 using batteryQI.Views;
 using System.Windows.Controls;
+using System.Data.Common;
 
 namespace batteryQI.ViewModels.Bases
 {
-    public partial class ViewModelBases : ObservableObject
+    public partial class ViewModelBases : ObservableObject, IDisposable
     {
         // DB 객체 생성
         protected DBlink _dblink;
         public ViewModelBases()
         {
             // 객체 연결
-            _dblink = DBlink.Instance(); 
+            _dblink = DBlink.Instance();
+        }
+
+        // Dispose 메서드 구현
+        public void Dispose()
+        {
+            if (_dblink != null)
+            {
+                _dblink.Dispose(); // 리소스 해제
+                _dblink = null;
+            }
         }
     }
 }

--- a/batteryQI_plus/ViewModels/CompositeViewModel.cs
+++ b/batteryQI_plus/ViewModels/CompositeViewModel.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace batteryQI.ViewModels
 {
     // 주석 달아주시죠.. 이거 만드신 분.. 
-    class CompositeViewModel
+    public class CompositeViewModel
     {
         public InspectViewModel InspectViewModel { get; set; }
         public ManagerViewModel ManagerViewModel { get; set; }

--- a/batteryQI_plus/ViewModels/CompositeViewModel.cs
+++ b/batteryQI_plus/ViewModels/CompositeViewModel.cs
@@ -3,11 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using batteryQI.ViewModels.Bases;
 
 namespace batteryQI.ViewModels
 {
     // 주석 달아주시죠.. 이거 만드신 분.. 
-    public class CompositeViewModel
+    public class CompositeViewModel : ViewModelBases
     {
         public InspectViewModel InspectViewModel { get; set; }
         public ManagerViewModel ManagerViewModel { get; set; }

--- a/batteryQI_plus/ViewModels/InspectViewModel.cs
+++ b/batteryQI_plus/ViewModels/InspectViewModel.cs
@@ -19,7 +19,7 @@ using System.Data.Common;
 namespace batteryQI.ViewModels
 {
     // 이미지 검사 이벤트
-    internal partial class InspectViewModel : ViewModelBases
+    public partial class InspectViewModel : ViewModelBases
     {
         
         // --------------------------------------------

--- a/batteryQI_plus/ViewModels/InspectViewModelEvent.cs
+++ b/batteryQI_plus/ViewModels/InspectViewModelEvent.cs
@@ -11,7 +11,7 @@ using CommunityToolkit.Mvvm.Input;
 
 namespace batteryQI.ViewModels
 {
-    internal partial class InspectViewModel : ViewModelBases
+    public partial class InspectViewModel : ViewModelBases
     {
         // InspectViewModel 이벤트 핸들러 정리 파일
         [RelayCommand]

--- a/batteryQI_plus/ViewModels/InspectViewModelIlist.cs
+++ b/batteryQI_plus/ViewModels/InspectViewModelIlist.cs
@@ -9,7 +9,7 @@ using batteryQI.ViewModels.Bases;
 
 namespace batteryQI.ViewModels
 {
-    internal partial class InspectViewModel : ViewModelBases
+    public partial class InspectViewModel : ViewModelBases
     {
         // combox 리스트
 

--- a/batteryQI_plus/ViewModels/MainWindowViewModel.cs
+++ b/batteryQI_plus/ViewModels/MainWindowViewModel.cs
@@ -14,7 +14,7 @@ using System.Data.Common;
 
 namespace batteryQI.ViewModels
 {
-    internal partial class MainWindowViewModel : ViewModelBases
+    public partial class MainWindowViewModel : ViewModelBases
     {
         private object _currentPage;
         public object CurrentPage

--- a/batteryQI_plus/ViewModels/MainWindowViewModel.cs
+++ b/batteryQI_plus/ViewModels/MainWindowViewModel.cs
@@ -51,7 +51,7 @@ namespace batteryQI.ViewModels
         [RelayCommand]
         private void ExitButton()
         {
-            _dblink.Disconnect(); // DB 연결 끊기
+            _dblink.Dispose(); // DB 연결 끊기
             CloseAction?.Invoke();
         }
     }

--- a/batteryQI_plus/ViewModels/ManagerViewModel.cs
+++ b/batteryQI_plus/ViewModels/ManagerViewModel.cs
@@ -18,7 +18,7 @@ using System.Collections.ObjectModel;
 namespace batteryQI.ViewModels
 {
     // 관리자 페이지
-    internal partial class ManagerViewModel : ViewModelBases
+    public partial class ManagerViewModel : ViewModelBases
     {
         private Manager _manager = Manager.Instance();
         private string _manufacName = "";

--- a/batteryQI_plus/ViewModels/ViewModelLocator.cs
+++ b/batteryQI_plus/ViewModels/ViewModelLocator.cs
@@ -84,5 +84,45 @@ namespace batteryQI.ViewModels
                 return _tabControlViewModel;
             }
         }
+
+        public void Cleanup()
+        {
+            if (_loginViewModel != null)
+            {
+                _loginViewModel.Dispose();
+                _loginViewModel = null;
+            }
+
+            if (_mainWindowViewModel != null)
+            {
+                _mainWindowViewModel.Dispose();
+                _mainWindowViewModel = null;
+            }
+
+            // 얘는 다른 방식으로 처리할 수 있으면 처리 시도해야함 응급처치로 ViewModelBase상속하게 해서 해결했음
+            if (_compositeViewModel != null) 
+            {
+                _compositeViewModel.Dispose();
+                _compositeViewModel = null;
+            }
+
+            if (_inspectViewModel != null)
+            {
+                _inspectViewModel.Dispose();
+                _inspectViewModel = null;
+            }
+
+            if (_managerViewModel != null)
+            {
+                _managerViewModel.Dispose();
+                _managerViewModel = null;
+            }
+
+            if (_tabControlViewModel != null)
+            {
+                _tabControlViewModel.Dispose();
+                _tabControlViewModel = null;
+            }
+        }
     }
 }

--- a/batteryQI_plus/ViewModels/ViewModelLocator.cs
+++ b/batteryQI_plus/ViewModels/ViewModelLocator.cs
@@ -1,0 +1,88 @@
+﻿using batteryQI.ViewModels.Bases;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace batteryQI.ViewModels
+{
+    public class ViewModelLocator
+    {
+        public ViewModelLocator()
+        {
+            //_loginViewModel = new LoginViewModel();
+            //_mainWindowViewModel = new MainWindowViewModel();
+            //_compositeViewModel = new CompositeViewModel();
+            //_inspectViewModel = new InspectViewModel();
+            //_managerViewModel = new ManagerViewModel();
+            //_tabControlViewModel = new TabControlViewModel();
+        }
+
+        private LoginViewModel? _loginViewModel; // 로그인 View
+        public LoginViewModel LoginViewModel
+        {
+            get
+            {
+                if (_loginViewModel == null)
+                    _loginViewModel = new LoginViewModel();
+                return _loginViewModel;
+            }
+        }
+
+        private MainWindowViewModel? _mainWindowViewModel; // 메인화면 View
+        public MainWindowViewModel MainWindowViewModel
+        {
+            get
+            {
+                if (_mainWindowViewModel == null)
+                    _mainWindowViewModel = new MainWindowViewModel();
+                return _mainWindowViewModel;
+            }
+        }
+
+        private CompositeViewModel? _compositeViewModel; // 데시보드, 불량정보확인 View
+        public CompositeViewModel CompositeViewModel
+        {
+            get
+            {
+                if (_compositeViewModel == null)
+                    _compositeViewModel = new CompositeViewModel();
+                return _compositeViewModel;
+            }
+        }
+
+        private InspectViewModel? _inspectViewModel; // 불량유형확인 View
+        public InspectViewModel InspectViewModel
+        {
+            get
+            {
+                if (_inspectViewModel == null)
+                    _inspectViewModel = new InspectViewModel();
+                return _inspectViewModel;
+            }
+        }
+
+        private ManagerViewModel? _managerViewModel; // 관리자 View
+        public ManagerViewModel ManagerViewModel
+        {
+            get
+            {
+                if (_managerViewModel == null)
+                    _managerViewModel = new ManagerViewModel();
+                return _managerViewModel;
+            }
+        }
+
+        private TabControlViewModel? _tabControlViewModel; // 차트 View
+        public TabControlViewModel TabControlViewModel
+        {
+            get
+            {
+                if (_tabControlViewModel == null)
+                    _tabControlViewModel = new TabControlViewModel();
+                return _tabControlViewModel;
+            }
+        }
+    }
+}

--- a/batteryQI_plus/ViewModels/loginViewModel.cs
+++ b/batteryQI_plus/ViewModels/loginViewModel.cs
@@ -14,7 +14,7 @@ using CommunityToolkit.Mvvm.Input;
 
 namespace batteryQI.ViewModels.Bases
 {
-    internal partial class LoginViewModel : ViewModelBases
+    public partial class LoginViewModel : ViewModelBases
     {
         private Manager _manager = Manager.Instance();
         public Manager Manager

--- a/batteryQI_plus/Views/ErrorInfoView.xaml
+++ b/batteryQI_plus/Views/ErrorInfoView.xaml
@@ -1,7 +1,11 @@
 ﻿<Window x:Class="batteryQI.Views.ErrorInfoView"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Height="600" Width="880">
+        Height="600" Width="880"
+        >
+    <Window.DataContext>
+        <Binding Path="CompositeViewModel" Source="{StaticResource Locator}" />
+    </Window.DataContext>
 
     <Border Background="#cfd5e5" CornerRadius="10" BorderThickness="2" BorderBrush="#ebedf3" Padding="20">
         <Border CornerRadius="30">

--- a/batteryQI_plus/Views/ErrorInfoView.xaml.cs
+++ b/batteryQI_plus/Views/ErrorInfoView.xaml.cs
@@ -23,7 +23,7 @@ namespace batteryQI.Views
         public ErrorInfoView()
         {
             InitializeComponent();
-            this.DataContext = new CompositeViewModel();
+            //this.DataContext = new CompositeViewModel();
         }
     }
 }

--- a/batteryQI_plus/Views/InspectionImage.xaml
+++ b/batteryQI_plus/Views/InspectionImage.xaml
@@ -2,7 +2,9 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:uc="clr-namespace:batteryQI.Views.UserControls"
-        Height="750" Width="500">
+        Height="750" Width="500"
+        DataContext="{Binding InspectViewModel, Source={StaticResource Locator}}"
+        >
 
     <Border Background="#cfd5e5" CornerRadius="10" BorderThickness="2" BorderBrush="#ebedf3" Padding="20">
         <Border CornerRadius="30">

--- a/batteryQI_plus/Views/InspectionImage.xaml.cs
+++ b/batteryQI_plus/Views/InspectionImage.xaml.cs
@@ -24,7 +24,7 @@ namespace batteryQI.Views
         public InspectionImage()
         {
             InitializeComponent();
-            this.DataContext = new InspectViewModel();
+            //this.DataContext = new InspectViewModel();
         }
     }
 }

--- a/batteryQI_plus/Views/LoginWindow.xaml
+++ b/batteryQI_plus/Views/LoginWindow.xaml
@@ -3,7 +3,12 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:batteryQI.Views"
         xmlns:vm="clr-namespace:batteryQI.ViewModels.Bases"
-        Title="LoginWindow" Height="450" Width="800">
+        Title="LoginWindow" Height="450" Width="800"
+        >
+    <Window.DataContext>
+        <Binding Path="LoginViewModel" Source="{StaticResource Locator}" />
+    </Window.DataContext>
+
     <Border Background="#cfd5e5" CornerRadius="10" BorderThickness="2" BorderBrush="#ebedf3" Padding="20">
         <Border CornerRadius="30">
             <Border.Background>

--- a/batteryQI_plus/Views/LoginWindow.xaml.cs
+++ b/batteryQI_plus/Views/LoginWindow.xaml.cs
@@ -23,7 +23,7 @@ namespace batteryQI.Views
         public LoginWindow()
         {
             InitializeComponent();
-            this.DataContext = new LoginViewModel();
+            //this.DataContext = new LoginViewModel();
         }
     }
 }

--- a/batteryQI_plus/Views/MainWindow.xaml
+++ b/batteryQI_plus/Views/MainWindow.xaml
@@ -7,7 +7,9 @@
         Title="BatteryQI"         
         WindowStartupLocation="CenterScreen" 
         WindowState="Maximized" 
-        Background="White">
+        Background="White" 
+        DataContext="{Binding MainWindowViewModel, Source={StaticResource Locator}}"
+    >
 
     <Border Background="#cfd5e5" CornerRadius="10" BorderThickness="2" BorderBrush="#ebedf3"
     Padding="20">

--- a/batteryQI_plus/Views/MainWindow.xaml.cs
+++ b/batteryQI_plus/Views/MainWindow.xaml.cs
@@ -22,9 +22,13 @@ namespace batteryQI.Views
         public MainWindow()
         {
             InitializeComponent();
-            var viewModel = new MainWindowViewModel();
-            viewModel.CloseAction = () => this.Close();
-            this.DataContext = viewModel;
+            //var viewModel = new MainWindowViewModel();
+            //viewModel.CloseAction = () => this.Close();
+            //this.DataContext = viewModel;
+            if (DataContext is MainWindowViewModel vm)
+            {
+                vm.CloseAction = () => this.Close(); // 창 닫기 기능을 ViewModel에 연결
+            }
         }
     }
 }

--- a/batteryQI_plus/Views/UserControls/ChartView.xaml
+++ b/batteryQI_plus/Views/UserControls/ChartView.xaml
@@ -2,24 +2,30 @@
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:local="clr-namespace:batteryQI.Extensions"
-             xmlns:vm="clr-namespace:batteryQI.ViewModels">
+             xmlns:vm="clr-namespace:batteryQI.ViewModels"
+             >
+    <UserControl.DataContext>
+        <Binding Path="TabControlViewModel" Source="{StaticResource Locator}" />
+    </UserControl.DataContext>
 
-    <Grid x:Name="MainGrid" Margin="0 70">
-        <!-- TabControl with SelectionChanged event -->
-        <TabControl ItemsSource="{Binding Tabs}"
+    <Border Background="White">
+        <Grid x:Name="MainGrid" Margin="0 70">
+            <!-- TabControl with SelectionChanged event -->
+            <TabControl ItemsSource="{Binding Tabs}"
                     SelectedItem="{Binding SelectedTab}"
                     Margin="10">
-            <TabControl.ItemTemplate>
-                <DataTemplate>
-                    <TextBlock Text="{Binding Header}"/>
-                </DataTemplate>
-            </TabControl.ItemTemplate>
-            <TabControl.ContentTemplate>
-                <!-- ChartView와 ChartViewModel과 PlotExtension(첨부속성)을 연결하여 사용하는 부분 -->
-                <DataTemplate>
-                    <WpfPlot local:PlotExtensions.PlotData="{Binding Content}"/>
-                </DataTemplate>
-            </TabControl.ContentTemplate>
-        </TabControl>
-    </Grid>
+                <TabControl.ItemTemplate>
+                    <DataTemplate>
+                        <TextBlock Text="{Binding Header}"/>
+                    </DataTemplate>
+                </TabControl.ItemTemplate>
+                <TabControl.ContentTemplate>
+                    <!-- ChartView와 ChartViewModel과 PlotExtension(첨부속성)을 연결하여 사용하는 부분 -->
+                    <DataTemplate>
+                        <WpfPlot local:PlotExtensions.PlotData="{Binding Content}"/>
+                    </DataTemplate>
+                </TabControl.ContentTemplate>
+            </TabControl>
+        </Grid>
+    </Border>
 </UserControl>

--- a/batteryQI_plus/Views/UserControls/ChartView.xaml.cs
+++ b/batteryQI_plus/Views/UserControls/ChartView.xaml.cs
@@ -27,7 +27,7 @@ namespace batteryQI.Views.UserControls
         public ChartView()
         {
             InitializeComponent();
-            this.DataContext = new TabControlViewModel();
+            //this.DataContext = new TabControlViewModel();
         }
     }
 }

--- a/batteryQI_plus/Views/UserControls/DashboardView.xaml
+++ b/batteryQI_plus/Views/UserControls/DashboardView.xaml
@@ -1,166 +1,172 @@
 ﻿<UserControl x:Class="batteryQI.Views.UserControls.DashboardView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             >
+    <UserControl.DataContext>
+        <Binding Path="CompositeViewModel" Source="{StaticResource Locator}" />
+    </UserControl.DataContext>
+    
+    <Border Background="White">
+        <Viewbox Stretch="Uniform">
+            <Grid Width="1280" Height="720">
+                <Grid>
+                    <!-- Main Section -->
+                    <Grid x:Name="mainSection" Margin="5 20 25 10" Panel.ZIndex="1">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="550"/>
+                            <RowDefinition Height="220"/>
+                        </Grid.RowDefinitions>
 
-    <Viewbox Stretch="Uniform">
-        <Grid Width="1280" Height="720">
-            <Grid>
-                <!-- Main Section -->
-                <Grid x:Name="mainSection" Margin="5 20 25 10" Panel.ZIndex="1">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="550"/>
-                        <RowDefinition Height="220"/>
-                    </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="2*"/>
+                            <ColumnDefinition Width="3*"/>
+                            <ColumnDefinition Width="2*"/>
+                        </Grid.ColumnDefinitions>
 
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="2*"/>
-                        <ColumnDefinition Width="3*"/>
-                        <ColumnDefinition Width="2*"/>
-                    </Grid.ColumnDefinitions>
+                        <!--Main Image Insert Section-->
+                        <Border Grid.Row="0" Grid.ColumnSpan="2" CornerRadius="20" Margin="0 0 20 20">
+                            <Border.Background>
+                                <LinearGradientBrush StartPoint="0.5,0" EndPoint="0.5,1">
+                                    <GradientStop Color="#6a5dae" Offset="0"/>
+                                    <GradientStop Color="#54479c" Offset="1.2"/>
+                                </LinearGradientBrush>
+                            </Border.Background>
 
-                    <!--Main Image Insert Section-->
-                    <Border Grid.Row="0" Grid.ColumnSpan="2" CornerRadius="20" Margin="0 0 20 20">
-                        <Border.Background>
-                            <LinearGradientBrush StartPoint="0.5,0" EndPoint="0.5,1">
-                                <GradientStop Color="#6a5dae" Offset="0"/>
-                                <GradientStop Color="#54479c" Offset="1.2"/>
-                            </LinearGradientBrush>
-                        </Border.Background>
+                            <!--Main Image PreView Section-->
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
 
-                        <!--Main Image PreView Section-->
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="Auto"/>
-                                <RowDefinition Height="*"/>
-                                <RowDefinition Height="Auto"/>
-                            </Grid.RowDefinitions>
+                                <TextBlock Text="배터리 이미지" Margin="20 15" FontSize="20" FontWeight="SemiBold" Foreground="White" VerticalAlignment="Top"/>
 
-                            <TextBlock Text="배터리 이미지" Margin="20 15" FontSize="20" FontWeight="SemiBold" Foreground="White" VerticalAlignment="Top"/>
+                                <Border CornerRadius="10" Margin="20,70,20,70" ClipToBounds="True" Height="370" VerticalAlignment="Top">
+                                    <Border.Background>
+                                        <LinearGradientBrush StartPoint="0.5,0" EndPoint="0.5,1">
+                                            <GradientStop Color="White" Offset="0"/>
+                                            <GradientStop Color="White" Offset="1.2"/>
+                                        </LinearGradientBrush>
+                                    </Border.Background>
 
-                            <Border CornerRadius="10" Margin="20,70,20,70" ClipToBounds="True" Height="370" VerticalAlignment="Top">
-                                <Border.Background>
-                                    <LinearGradientBrush StartPoint="0.5,0" EndPoint="0.5,1">
-                                        <GradientStop Color="White" Offset="0"/>
-                                        <GradientStop Color="White" Offset="1.2"/>
-                                    </LinearGradientBrush>
-                                </Border.Background>
+                                    <Image Source="{Binding DataContext.InspectViewModel.battery.ImagePath, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}" Stretch="Uniform" x:Name="PreviewImage" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                                </Border>
 
-                                <Image Source="{Binding DataContext.InspectViewModel.battery.ImagePath, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}" Stretch="Uniform" x:Name="PreviewImage" VerticalAlignment="Center" HorizontalAlignment="Center"/>
-                            </Border>
+                                <Button Style="{StaticResource imageSectionButton}" Margin="0 460 0 0" Content="이미지 선택" Command="{Binding InspectViewModel.ImageSelectButton_ClickCommand}" FontSize="17" FontWeight="SemiBold" />
+                            </Grid>
+                        </Border>
 
-                            <Button Style="{StaticResource imageSectionButton}" Margin="0 460 0 0" Content="이미지 선택" Command="{Binding InspectViewModel.ImageSelectButton_ClickCommand}" FontSize="17" FontWeight="SemiBold" />
-                        </Grid>
-                    </Border>
+                        <!-- Image Info Section-->
+                        <Grid Grid.Column="2" Grid.Row="0">
+                            <Border CornerRadius="20" Background="#7163ba" Margin="0,0,0,22">
+                                <StackPanel Orientation="Vertical" Margin="20 20 20 0">
+                                    <TextBlock Text="배터리 이미지 정보" Margin="0 0 0 0" FontSize="20" FontWeight="SemiBold" Foreground="White" VerticalAlignment="Top" HorizontalAlignment="Center"/>
 
-                    <!-- Image Info Section-->
-                    <Grid Grid.Column="2" Grid.Row="0">
-                        <Border CornerRadius="20" Background="#7163ba" Margin="0,0,0,22">
-                            <StackPanel Orientation="Vertical" Margin="20 20 20 0">
-                                <TextBlock Text="배터리 이미지 정보" Margin="0 0 0 0" FontSize="20" FontWeight="SemiBold" Foreground="White" VerticalAlignment="Top" HorizontalAlignment="Center"/>
-
-                                <StackPanel Orientation="Vertical" Margin="10 40 0 0">
-                                    <TextBlock Text="제조사" FontSize="14" FontWeight="SemiBold" Foreground="White" Margin="75 5 5 5"/>
-                                    <ComboBox x:Name="manufacture"
+                                    <StackPanel Orientation="Vertical" Margin="10 40 0 0">
+                                        <TextBlock Text="제조사" FontSize="14" FontWeight="SemiBold" Foreground="White" Margin="75 5 5 5"/>
+                                        <ComboBox x:Name="manufacture"
                                   ItemsSource="{Binding Path = DataContext.InspectViewModel.ManufacList, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}"
                                   SelectedValue="{Binding DataContext.InspectViewModel.battery.ManufacName, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"  Width="150" Margin="0 10 0 0">
-                                        <ComboBox.ItemTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding}"/>
-                                            </DataTemplate>
-                                        </ComboBox.ItemTemplate>
-                                    </ComboBox>
-                                </StackPanel>
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock Text="{Binding}"/>
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                    </StackPanel>
 
-                                <StackPanel Orientation="Vertical" Margin="10 20 0 0">
-                                    <TextBlock Text="배터리 타입" FontSize="14" FontWeight="SemiBold" Foreground="White" Margin="75 5 5 5"/>
-                                    <ComboBox x:Name="batteryType"
+                                    <StackPanel Orientation="Vertical" Margin="10 20 0 0">
+                                        <TextBlock Text="배터리 타입" FontSize="14" FontWeight="SemiBold" Foreground="White" Margin="75 5 5 5"/>
+                                        <ComboBox x:Name="batteryType"
                                   ItemsSource="{Binding Path = DataContext.InspectViewModel.BatteryTypeList, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}"
                                   SelectedValue="{Binding DataContext.InspectViewModel.battery.BatteryType, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="150" Margin="0 10 0 0">
-                                        <ComboBox.ItemTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding}"/>
-                                            </DataTemplate>
-                                        </ComboBox.ItemTemplate>
-                                    </ComboBox>
-                                </StackPanel>
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock Text="{Binding}"/>
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                    </StackPanel>
 
-                                <StackPanel Orientation="Vertical" Margin="10 20 0 0">
-                                    <TextBlock Text="배터리 형태" FontSize="14" FontWeight="SemiBold" Foreground="White" Margin="75 5 5 5"/>
-                                    <ComboBox x:Name="batteryShape"
+                                    <StackPanel Orientation="Vertical" Margin="10 20 0 0">
+                                        <TextBlock Text="배터리 형태" FontSize="14" FontWeight="SemiBold" Foreground="White" Margin="75 5 5 5"/>
+                                        <ComboBox x:Name="batteryShape"
                                   ItemsSource="{Binding Path = DataContext.InspectViewModel.BatteryShapeList, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}"
                                   SelectedValue="{Binding DataContext.InspectViewModel.battery.BatteryShape, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="150" Margin="0 10 0 0">
-                                        <ComboBox.ItemTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding}"/>
-                                            </DataTemplate>
-                                        </ComboBox.ItemTemplate>
-                                    </ComboBox>
-                                </StackPanel>
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock Text="{Binding}"/>
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                    </StackPanel>
 
-                                <StackPanel Orientation="Vertical" Margin="10 20 0 0">
-                                    <TextBlock Text="사용처" FontSize="14" FontWeight="SemiBold" Foreground="White" Margin="75 5 5 5"/>
-                                    <ComboBox 
+                                    <StackPanel Orientation="Vertical" Margin="10 20 0 0">
+                                        <TextBlock Text="사용처" FontSize="14" FontWeight="SemiBold" Foreground="White" Margin="75 5 5 5"/>
+                                        <ComboBox 
                             x:Name="battryUsage"
                             ItemsSource = "{Binding Path = DataContext.InspectViewModel.UsageList, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}"
                             SelectedValue="{Binding DataContext.InspectViewModel.battery.Usage, Mode=TwoWay, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}, UpdateSourceTrigger=PropertyChanged}" Width="150" Margin="0 10 0 0">
-                                        <ComboBox.ItemTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding}"/>
-                                            </DataTemplate>
-                                        </ComboBox.ItemTemplate>
-                                    </ComboBox>
-                                </StackPanel>
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock Text="{Binding}"/>
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+                                    </StackPanel>
 
-                                <Button Style="{StaticResource imageSectionButton}" Margin="0 65 0 0" Content="이미지 분석" FontSize="17" FontWeight="SemiBold" 
+                                    <Button Style="{StaticResource imageSectionButton}" Margin="0 65 0 0" Content="이미지 분석" FontSize="17" FontWeight="SemiBold" 
                                     Command="{Binding DataContext.InspectViewModel.ImageInspectionButton_ClickCommand, RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}"/>
 
-                            </StackPanel>
+                                </StackPanel>
+                            </Border>
+                        </Grid>
+
+                        <!-- Progress Section -->
+                        <Border Grid.Row="1" Grid.ColumnSpan="3" CornerRadius="10" Background="#7163ba" Padding="0 0 0 10" Margin="0,20,0,83">
+                            <Grid>
+                                <StackPanel Orientation="Vertical">
+                                    <!-- 제목 -->
+                                    <TextBlock Margin="10" Text="검사 진행률" FontSize="17" Foreground="White" FontWeight="SemiBold" />
+
+                                    <!-- 검사 정보 -->
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock Margin="20 0 0 0" Text="{Binding ManagerViewModel.Manager.WorkAmount, Mode=Oneway, UpdateSourceTrigger=PropertyChanged, StringFormat='할당량: {0}'}" 
+                                               Foreground="White" FontSize="15"/>
+                                        <TextBlock Margin="20 0 0 0" Text="{Binding ManagerViewModel.Manager.TotalInspectNum, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, StringFormat='검사 완료: {0}'}" 
+                                               Foreground="White" FontSize="15"/>
+                                        <TextBlock Margin="20 0 0 0" Text="{Binding ManagerViewModel.Manager.WorkProgress, Mode=Oneway, UpdateSourceTrigger=PropertyChanged, StringFormat='작업 진행률: {0}%'}"
+                                               Foreground="White" FontSize="15"/>
+                                    </StackPanel>
+
+                                    <!-- ProgressBar와 퍼센트 -->
+                                    <Grid Margin="20 10 20 0" VerticalAlignment="Center">
+                                        <!-- ProgressBar -->
+                                        <ProgressBar Height="20" Value="{Binding ManagerViewModel.Manager.WorkProgress, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Maximum="100">
+                                            <ProgressBar.Resources>
+                                                <!-- ProgressBar 색상 변경 -->
+                                                <Style TargetType="ProgressBar">
+                                                    <Setter Property="Foreground" Value="#E5D1FF" />
+                                                    <!-- 진행 부분 색상 -->
+                                                    <Setter Property="Background" Value="#9A8CCC" />
+                                                    <!-- 배경 색상 -->
+                                                </Style>
+                                            </ProgressBar.Resources>
+                                        </ProgressBar>
+
+                                        <!-- 퍼센트 텍스트 -->
+                                        <TextBlock HorizontalAlignment="Right" Foreground="#54479c" VerticalAlignment="Center" Margin="0 0 10 0" FontSize="14" FontWeight="SemiBold" Text="{Binding ManagerViewModel.Manager.WorkProgress, Mode=Oneway, UpdateSourceTrigger=PropertyChanged, StringFormat=' {0}%'}" />
+                                    </Grid>
+                                </StackPanel>
+                            </Grid>
                         </Border>
+
+                        <Frame x:Name="MainFrame" NavigationUIVisibility="Hidden"/>
                     </Grid>
 
-                    <!-- Progress Section -->
-                    <Border Grid.Row="1" Grid.ColumnSpan="3" CornerRadius="10" Background="#7163ba" Padding="0 0 0 10" Margin="0,20,0,83">
-                        <Grid>
-                            <StackPanel Orientation="Vertical">
-                                <!-- 제목 -->
-                                <TextBlock Margin="10" Text="검사 진행률" FontSize="17" Foreground="White" FontWeight="SemiBold" />
-
-                                <!-- 검사 정보 -->
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock Margin="20 0 0 0" Text="{Binding ManagerViewModel.Manager.WorkAmount, Mode=Oneway, UpdateSourceTrigger=PropertyChanged, StringFormat='할당량: {0}'}" 
-                                               Foreground="White" FontSize="15"/>
-                                    <TextBlock Margin="20 0 0 0" Text="{Binding ManagerViewModel.Manager.TotalInspectNum, Mode=OneWay, UpdateSourceTrigger=PropertyChanged, StringFormat='검사 완료: {0}'}" 
-                                               Foreground="White" FontSize="15"/>
-                                    <TextBlock Margin="20 0 0 0" Text="{Binding ManagerViewModel.Manager.WorkProgress, Mode=Oneway, UpdateSourceTrigger=PropertyChanged, StringFormat='작업 진행률: {0}%'}"
-                                               Foreground="White" FontSize="15"/>
-                                </StackPanel>
-
-                                <!-- ProgressBar와 퍼센트 -->
-                                <Grid Margin="20 10 20 0" VerticalAlignment="Center">
-                                    <!-- ProgressBar -->
-                                    <ProgressBar Height="20" Value="{Binding ManagerViewModel.Manager.WorkProgress, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" Maximum="100">
-                                        <ProgressBar.Resources>
-                                            <!-- ProgressBar 색상 변경 -->
-                                            <Style TargetType="ProgressBar">
-                                                <Setter Property="Foreground" Value="#E5D1FF" />
-                                                <!-- 진행 부분 색상 -->
-                                                <Setter Property="Background" Value="#9A8CCC" />
-                                                <!-- 배경 색상 -->
-                                            </Style>
-                                        </ProgressBar.Resources>
-                                    </ProgressBar>
-
-                                    <!-- 퍼센트 텍스트 -->
-                                    <TextBlock HorizontalAlignment="Right" Foreground="#54479c" VerticalAlignment="Center" Margin="0 0 10 0" FontSize="14" FontWeight="SemiBold" Text="{Binding ManagerViewModel.Manager.WorkProgress, Mode=Oneway, UpdateSourceTrigger=PropertyChanged, StringFormat=' {0}%'}" />
-                                </Grid>
-                            </StackPanel>
-                        </Grid>
-                    </Border>
-
-                    <Frame x:Name="MainFrame" NavigationUIVisibility="Hidden"/>
                 </Grid>
-
             </Grid>
-        </Grid>
-    </Viewbox>
+        </Viewbox>
+    </Border>
 </UserControl>

--- a/batteryQI_plus/Views/UserControls/DashboardView.xaml.cs
+++ b/batteryQI_plus/Views/UserControls/DashboardView.xaml.cs
@@ -26,7 +26,7 @@ namespace batteryQI.Views.UserControls
         public DashboardView()
         {
             InitializeComponent();
-            this.DataContext = new CompositeViewModel(); // ViewModel 연결
+            //this.DataContext = new CompositeViewModel(); // ViewModel 연결
         }
 
     }

--- a/batteryQI_plus/Views/UserControls/ManagerView.xaml
+++ b/batteryQI_plus/Views/UserControls/ManagerView.xaml
@@ -4,64 +4,69 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             d:DesignHeight="300" d:DesignWidth="400">
+             d:DesignHeight="300" d:DesignWidth="400"
+             >
+    <UserControl.DataContext>
+        <Binding Path="ManagerViewModel" Source="{StaticResource Locator}" />
+    </UserControl.DataContext>
 
-    <Viewbox Stretch="Uniform">
-        <Grid Width="1280" Height="720">
-
-            <Grid Margin="10 50">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                </Grid.RowDefinitions>
-
-                <!-- Monthly Inspection Allocation -->
-                <StackPanel Orientation="Horizontal" VerticalAlignment="Top" Margin="0 0 0 10">
-                    <TextBlock Text="월 검사 할당량" VerticalAlignment="Center" Margin="0 0 5 0" FontSize="25" FontWeight="SemiBold"/>
-                    <TextBox Text="{Binding NewAmount, UpdateSourceTrigger=PropertyChanged}"
-                     x:Name="InspectionLimitBox" Width="150" VerticalAlignment="Center" Margin="20 0 5 0" Height="auto" FontSize="20" TextChanged="InspectionLimitBox_TextChanged"/>
-                    <TextBlock Text="건" VerticalAlignment="Center" Margin="0 0 10 0" FontSize="25" FontWeight="SemiBold"/>
-                    <Button Content="저장"
-                    Width="70" Height="40"
-                    VerticalAlignment="Center"
-                    Style="{StaticResource commonButton}" Margin="5 0 0 0" FontSize="20"        
-                    Command="{Binding amountSaveButton_ClickCommand}" />
-                </StackPanel>
-
-                <!-- Manufacturer List -->
-                <Grid Grid.Row="1">
+    <Border Background="White">
+        <Viewbox Stretch="Uniform">
+            <Grid Width="1280" Height="720">
+                <Grid Margin="10 50">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="*" />
                     </Grid.RowDefinitions>
 
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Top" Margin="0 0 0 5">
-                        <TextBlock Text="제조사 리스트" FontWeight="Bold" VerticalAlignment="Center" FontSize="25"/>
-                        <TextBox Text="{Binding ManufacName, UpdateSourceTrigger=PropertyChanged}"
-                         Width="150" Height="auto" VerticalAlignment="Center" Margin="32 0 5 0" FontSize="20"/>
-                        <Button Content="추가" FontSize="20" Width="70" Height="40" VerticalAlignment="Center" Margin="42 0 0 0"
-                                Style="{StaticResource commonButton}"
-                        Command="{Binding ManufactInsertCommand}" />
+                    <!-- Monthly Inspection Allocation -->
+                    <StackPanel Orientation="Horizontal" VerticalAlignment="Top" Margin="0 0 0 10">
+                        <TextBlock Text="월 검사 할당량" VerticalAlignment="Center" Margin="0 0 5 0" FontSize="25" FontWeight="SemiBold"/>
+                        <TextBox Text="{Binding NewAmount, UpdateSourceTrigger=PropertyChanged}"
+                         x:Name="InspectionLimitBox" Width="150" VerticalAlignment="Center" Margin="20 0 5 0" Height="auto" FontSize="20" TextChanged="InspectionLimitBox_TextChanged"/>
+                        <TextBlock Text="건" VerticalAlignment="Center" Margin="0 0 10 0" FontSize="25" FontWeight="SemiBold"/>
+                        <Button Content="저장"
+                        Width="70" Height="40"
+                        VerticalAlignment="Center"
+                        Style="{StaticResource commonButton}" Margin="5 0 0 0" FontSize="20"        
+                        Command="{Binding amountSaveButton_ClickCommand}" />
                     </StackPanel>
 
-                    <Border Grid.Row="1" Margin="0 50 0 0" BorderBrush="#7163ba" BorderThickness="2" Width="700" HorizontalAlignment="Left" CornerRadius="10">
-                        <ListBox ItemsSource="{Binding ManufacCollection}" BorderBrush="Transparent" Background="Transparent" x:Name="ManufacItems">
-                            <ListBox.ItemTemplate>
-                                <DataTemplate>
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto" />
-                                            <ColumnDefinition Width="*" />
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock Grid.Column="0" Text="{Binding Value}" Margin="0 8 5 0" FontWeight="Bold" FontSize="20"/>
-                                        <TextBlock Grid.Column="1" Text="{Binding Key}" Margin="0 8 0 0" FontSize="20"/>
-                                    </Grid>
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
-                    </Border>
+                    <!-- Manufacturer List -->
+                    <Grid Grid.Row="1">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Top" Margin="0 0 0 5">
+                            <TextBlock Text="제조사 리스트" FontWeight="Bold" VerticalAlignment="Center" FontSize="25"/>
+                            <TextBox Text="{Binding ManufacName, UpdateSourceTrigger=PropertyChanged}"
+                             Width="150" Height="auto" VerticalAlignment="Center" Margin="32 0 5 0" FontSize="20"/>
+                            <Button Content="추가" FontSize="20" Width="70" Height="40" VerticalAlignment="Center" Margin="42 0 0 0"
+                                    Style="{StaticResource commonButton}"
+                            Command="{Binding ManufactInsertCommand}" />
+                        </StackPanel>
+
+                        <Border Grid.Row="1" Margin="0 50 0 0" BorderBrush="#7163ba" BorderThickness="2" Width="700" HorizontalAlignment="Left" CornerRadius="10">
+                            <ListBox ItemsSource="{Binding ManufacCollection}" BorderBrush="Transparent" Background="Transparent" x:Name="ManufacItems">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="*" />
+                                            </Grid.ColumnDefinitions>
+                                            <TextBlock Grid.Column="0" Text="{Binding Value}" Margin="0 8 5 0" FontWeight="Bold" FontSize="20"/>
+                                            <TextBlock Grid.Column="1" Text="{Binding Key}" Margin="0 8 0 0" FontSize="20"/>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                        </Border>
+                    </Grid>
                 </Grid>
             </Grid>
-        </Grid>
-    </Viewbox>
+        </Viewbox>
+    </Border>
 </UserControl>

--- a/batteryQI_plus/Views/UserControls/ManagerView.xaml.cs
+++ b/batteryQI_plus/Views/UserControls/ManagerView.xaml.cs
@@ -25,7 +25,7 @@ namespace batteryQI.Views.UserControls
         public ManagerView()
         {
             InitializeComponent();
-            this.DataContext = new ManagerViewModel();
+            //this.DataContext = new ManagerViewModel();
         }
 
         // 텍스트 입력 검사 이벤트 핸들러.새 작업량 설정에 정수만 입력 가능하도록 규제


### PR DESCRIPTION
기존에 View와 ViewModel을 연결하는 방식으로 사용하던 코드 비하인드에서 ViewModel의 인스턴스를 Datacontext로 설정해서 하는 방식에서 ViewModelLocator로 하는 방식으로 변경
그리고 변경방식에 따라 프로그램 종료 후에 Locator에 의해서 ViewModel의 인스턴스들이 남아서 DB에 연결되었을 때 실행되던 쿼리 실행부분 실행되면서 에러창 뜨던 것을 해결

자세한 해결방식에 대한 내용은 커밋코멘트 참고